### PR TITLE
GHA/masks/variable

### DIFF
--- a/.github/workflows/incorretly-mask-env-variables.yaml
+++ b/.github/workflows/incorretly-mask-env-variables.yaml
@@ -27,4 +27,4 @@ jobs:
         run: echo " This is secret GH_SECRET:${{ secrets.GH_SECRET }}"
 
       - name: Show variable
-        run: echo " This is variable GH_VARIABLE:${{ env.GH_VARIABLE }}"
+        run: echo " This is variable GH_VARIABLE:${{ env.GH_VARIABLE }}:"

--- a/.github/workflows/incorretly-mask-env-variables.yaml
+++ b/.github/workflows/incorretly-mask-env-variables.yaml
@@ -1,0 +1,30 @@
+# This workflow shows, how GHA incorrectly masks environment variables
+#  IF the value of the variables equals the value of the secret.
+#   - add GH_SECRET with value "VERYSECRET"
+#   - set an env variable with the same value "VERYSECRET"
+#   - echo both
+#
+
+name: Workflow mask variables
+
+on:
+# # RUNS NIGHTLY
+#   schedule:
+#   - cron: '0 0 * * *'  # GMT
+  push:
+
+
+
+
+jobs:
+  echo-variable-and-variables:
+    runs-on: ubuntu-latest
+    env:
+      GH_VARIABLE: "VERYSECRET"
+
+    steps:
+      - name: Show secret
+        run: echo " This is secret GH_SECRET:${{ secrets.GH_SECRET }}"
+
+      - name: Show variable
+        run: echo " This is variable GH_VARIABLE:${{ secrets.GH_VARIABLE }}"

--- a/.github/workflows/incorretly-mask-env-variables.yaml
+++ b/.github/workflows/incorretly-mask-env-variables.yaml
@@ -9,8 +9,8 @@ name: Workflow mask variables
 
 on:
 # # RUNS NIGHTLY
-#   schedule:
-#   - cron: '0 0 * * *'  # GMT
+  schedule:
+  - cron: '0 0 * 2 *'  # GMT
   push:
 
 
@@ -23,5 +23,5 @@ jobs:
       GH_VARIABLE: "VERYSECRET"
 
     steps:
-      - name: Show secret and variable
+      - name: Show GH_SECRET '${{ secrets.GH_SECRET }}' GH_VARIABLE '${{ env.GH_VARIABLE }}'
         run: echo " GH_SECRET '${{ secrets.GH_SECRET }}' GH_VARIABLE '${{ env.GH_VARIABLE }}'"

--- a/.github/workflows/incorretly-mask-env-variables.yaml
+++ b/.github/workflows/incorretly-mask-env-variables.yaml
@@ -27,4 +27,4 @@ jobs:
         run: echo " This is secret GH_SECRET:${{ secrets.GH_SECRET }}"
 
       - name: Show variable
-        run: echo " This is variable GH_VARIABLE:${{ secrets.GH_VARIABLE }}"
+        run: echo " This is variable GH_VARIABLE:${{ env.GH_VARIABLE }}"

--- a/.github/workflows/incorretly-mask-env-variables.yaml
+++ b/.github/workflows/incorretly-mask-env-variables.yaml
@@ -23,8 +23,5 @@ jobs:
       GH_VARIABLE: "VERYSECRET"
 
     steps:
-      - name: Show secret
-        run: echo " This is secret GH_SECRET:${{ secrets.GH_SECRET }}"
-
-      - name: Show variable
-        run: echo " This is variable GH_VARIABLE:${{ env.GH_VARIABLE }}:"
+      - name: Show secret and variable
+        run: echo " GH_SECRET '${{ secrets.GH_SECRET }}' GH_VARIABLE '${{ env.GH_VARIABLE }}'"


### PR DESCRIPTION
#### Create workflow to show GH secrets/variable with same value
This workflow shows, how GHA incorrectly masks environment variables 
**IF** the value of the variables equals the value of the secret. We do this:
  - add GH_SECRET with value "VERYSECRET"
  - set an env variable with the same value "VERYSECRET"
  - echo both

See any GHA run output for [Workflow mask variables](https://github.com/radiomix/gh-composite-action/actions/workflows/incorretly-mask-env-variables.yaml):
```
Run echo " GH_SECRET '***' GH_VARIABLE '***'"
 GH_SECRET '***' GH_VARIABLE '***'
```

for this workflow code sniped
https://github.com/radiomix/gh-composite-action/blob/e5f57f7344a7d1335913ff365757574ebb5fc9e2/.github/workflows/incorretly-mask-env-variables.yaml#L25-L27
